### PR TITLE
README: update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ You can use `pip install gawd` to install the latest available version from [PyP
 Pre-releases are available from the *main* branch on [GitHub](https://github.com/pooya-rostami/gawd)
 and can be installed with `pip install git+https://github.com/pooya-rostami/gawd`.
 
+Alternatively, `gawd` supports installation via Nix. To install `gawd` using Nix:
+- For a temporary environment, execute `nix-shell -p gawd`, which provides a shell with `gawd` available.
+- To leverage Nix flakes, a more modern approach, use `nix shell github:NixOS/nixpkgs#gawd` to enter an ephemeral shell environment or `nix run github:NixOS/nixpkgs#gawd` for running `gawd` directly without entering a shell.
+
 ## Usage
 
 ### As a command-line tool

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ You can use `pip install gawd` to install the latest available version from [PyP
 Pre-releases are available from the *main* branch on [GitHub](https://github.com/pooya-rostami/gawd)
 and can be installed with `pip install git+https://github.com/pooya-rostami/gawd`.
 
-Alternatively, `gawd` supports installation via Nix. To install `gawd` using Nix:
-- For a temporary environment, execute `nix-shell -p gawd`, which provides a shell with `gawd` available.
-- To leverage Nix flakes, a more modern approach, use `nix shell github:NixOS/nixpkgs#gawd` to enter an ephemeral shell environment or `nix run github:NixOS/nixpkgs#gawd` for running `gawd` directly without entering a shell.
+Alternatively, `gawd` is available via [Nix](https://search.nixos.org/packages?channel=unstable&show=gawd&from=0&size=50&sort=relevance&type=packages&query=gawd).
 
 ## Usage
 


### PR DESCRIPTION
Hello!

`gawd` is now [available on Nix](https://search.nixos.org/packages?channel=unstable&show=gawd&from=0&size=50&sort=relevance&type=packages&query=gawd). This pull request updates the `README` file with instructions for installing and using `gawd` through Nix.

The additions include step-by-step commands for installing `gawd` using both traditional Nix channels and the more modern Nix Flakes, ensuring users have the flexibility to choose the method that best fits their needs.

Thank you for considering this contribution to the project documentation!