### PR TITLE
Update Dependabot configuration for monthly checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,29 @@ updates:
     # Workflow files stored in the default location of `.github/workflows`
     directory: "/"
     schedule:
-      interval: "weekly"
-    # Allow up to 10 open pull requests for GHA dependencies (default is 5)
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    # Allow up to 3 open pull requests for GHA dependencies (default is 5)
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "security"
+    reviewers:
+      - "sgl-umons/maintainers"
+
+  # Python dependencies - security updates only
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    # Only security updates
+    labels:
+      - "dependencies"
+      - "security"
+    reviewers:
+      - "sgl-umons/maintainers"
+    ignore:
+      # Ignore all patch and minor updates for all dependencies
+      # Only major security updates will create PRs
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]


### PR DESCRIPTION
- increased the time window of checking to monthly instead of a weekly check for actions to reduce spamming 
- added Python dependency to check for major security updates
- make sure the reviewers are in the list of SGL-umons maintainers
- add labeling for easier filtering